### PR TITLE
Fix PUTUser to use authenticated ID

### DIFF
--- a/controllers/v1/user.go
+++ b/controllers/v1/user.go
@@ -38,7 +38,7 @@ func PUTUser(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, datatransfers.Response{Error: err.Error()})
 		return
 	}
-	if err = handlers.Handler.UpdateUser(uint(c.GetInt(constants.IsAuthenticatedKey)), user); err != nil {
+	if err = handlers.Handler.UpdateUser(c.GetUint(constants.UserIDKey), user); err != nil {
 		c.JSON(http.StatusNotModified, datatransfers.Response{Error: "failed updating user"})
 		return
 	}


### PR DESCRIPTION
## Summary
- use `c.GetUint(constants.UserIDKey)` in PUTUser

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686d6e3f72288331999caad631eaa2d5