### PR TITLE
Add AuthOnly middleware tests

### DIFF
--- a/tests/handlers/auth_test.go
+++ b/tests/handlers/auth_test.go
@@ -1,1 +1,36 @@
 package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/daystram/go-gin-gorm-boilerplate/constants"
+	"github.com/daystram/go-gin-gorm-boilerplate/utils"
+)
+
+func TestAuthOnly_Unauthenticated(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(constants.IsAuthenticatedKey, false)
+
+	utils.AuthOnly(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+func TestAuthOnly_Authenticated(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(constants.IsAuthenticatedKey, true)
+
+	utils.AuthOnly(c)
+
+	if c.IsAborted() {
+		t.Errorf("middleware aborted despite authenticated context")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for AuthOnly middleware

## Testing
- `go test ./tests/...`


------
https://chatgpt.com/codex/tasks/task_e_686d6e416dec8331bdb1c28edec3f18c